### PR TITLE
Final solution for switching from MD5 to SHA256.

### DIFF
--- a/lib/offsite_payments/integrations/migs.rb
+++ b/lib/offsite_payments/integrations/migs.rb
@@ -1,3 +1,6 @@
+require 'openssl'
+require 'base64'
+
 module OffsitePayments
   module Integrations #:nodoc:
     module Migs
@@ -5,6 +8,8 @@ module OffsitePayments
       # Overwrite this if you want to change the ANS production url
       mattr_accessor :production_url
       self.production_url = 'https://migs.mastercard.com.au/vpcpay'
+
+      HASH_ALGORITHM = 'SHA256'.freeze
 
       def self.service_url
         mode = OffsitePayments.mode
@@ -151,11 +156,17 @@ module OffsitePayments
 
         # This must be called at the end after all other fields have been added
         def add_secure_hash
-          sorted_values = @fields.sort_by(&:to_s).map(&:last)
-          input = @secret + sorted_values.join
-          hash = Digest::SHA256.hexdigest(input).upcase
-
+          # Per MIGS requirements we must stringify, sort fields alphabetically
+          # minus the 'vpc_' prefix, add back the 'vpc_' prefix after sorting,
+          # then join all fields as a query string separated by '&'.
+          sorted_values = @fields.stringify_keys
+                                 .map { |(k, v)| [k.gsub('vpc_', ''), v] }
+                                 .sort
+                                 .map { |i| "vpc_#{i[0]}=#{i[1]}" }
+                                 .join('&')
+          hash = OpenSSL::HMAC.hexdigest(HASH_ALGORITHM, [@secret].pack('H*'), sorted_values).upcase
           add_field('vpc_SecureHash', hash)
+          add_field('vpc_SecureHashType', 'SHA256')
         end
 
         mapping :account, 'vpc_Merchant'
@@ -184,7 +195,7 @@ module OffsitePayments
         end
 
         def message
-          return 'Response from MiGS could not be validated' if not @valid
+          return 'Response from MiGS could not be validated' unless @valid
           params['vpc_Message']
         end
 
@@ -250,12 +261,16 @@ module OffsitePayments
         end
 
         def secure_hash_matches?
-          return false if not params['vpc_SecureHash']
+          return false unless params['vpc_SecureHash']
           response = params.clone
           response.delete('vpc_SecureHash')
-          sorted_values = response.sort_by(&:to_s).map(&:last)
-          input = @options[:secret] + sorted_values.join
-          Digest::SHA256.hexdigest(input).upcase == secure_hash
+          response.delete('vpc_SecureHashType')
+          sorted_values = response.stringify_keys
+                                  .map { |(k, v)| [k.gsub('vpc_', ''), v] }
+                                  .sort.map { |i| "vpc_#{i[0]}=#{i[1]}" }
+                                  .join('&')
+          hash = OpenSSL::HMAC.hexdigest(HASH_ALGORITHM, [@options[:secret]].pack('H*'), sorted_values).upcase
+          hash == secure_hash
         end
 
         # Returns true if one of the following is true:


### PR DESCRIPTION
This pull request implements the required switch from MD5 to SHA256 hashing for MiGS transactions.

Specially we use OpenSSL::HMAC with SHA256 along with the customers secure secret to create a hash of the request data prior to sending.

Additionally we implement the same methodology to check the integrity of the response coming back from the gateway provider's server.

This solution is fully tested locally and in production.