### PR TITLE
Use newer Realex endpoints

### DIFF
--- a/lib/offsite_payments/integrations/realex_offsite.rb
+++ b/lib/offsite_payments/integrations/realex_offsite.rb
@@ -3,8 +3,8 @@ module OffsitePayments #:nodoc:
     module RealexOffsite
       mattr_accessor :production_url
       mattr_accessor :test_url
-      self.production_url = 'https://epage.payandshop.com/epage.cgi'
-      self.test_url       = 'https://hpp.sandbox.realexpayments.com/pay'
+      self.production_url = 'https://pay.realexpayments.com/pay'
+      self.test_url       = 'https://pay.sandbox.realexpayments.com/pay'
 
       def self.helper(order, account, options={})
         Helper.new(order, account, options)


### PR DESCRIPTION
These new endpoints support the proper deprecation of TLS 1 cipher suite.

I've run a successful live payment in ASL database from my local.

We should coordinate this with the server side TLS config change.